### PR TITLE
Use commits URL from PR event data

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,20 +58,15 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         COMMENT_TEXT: ${{ inputs.comment }}
         COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
+        COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       run: |
-        # Escape double quotes and newlines
-        COMMENT_TEXT="$(echo "$COMMENT_TEXT" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')"
-
-        GITHUB_PR=$(echo $GITHUB_REF | sed -n 's/refs\/pull\/\([0-9]*\)\/merge/\1/p')
-        if [[ -z "$GITHUB_PR" ]]; then
-          echo "No PR found to scan for commits."
-          exit 0
-        fi
-
-        unsigned_commits="$(curl -s -H "Authorization: token $GITHUB_TOKEN" "${GITHUB_API_URL:-https://api.github.com}/repos/$GITHUB_REPOSITORY/pulls/$GITHUB_PR/commits" | jq '.[] | select(.commit.verification.verified == false) | .commit.message')"
+        unsigned_commits="$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMITS_URL" | jq '.[] | select(.commit.verification.verified == false) | .commit.message')"
         if [[ -n "$unsigned_commits" ]]; then
           echo "Found unsigned commits:"
           echo "$unsigned_commits"
+
+          # Escape double quotes and newlines in comment
+          COMMENT_TEXT="$(echo "$COMMENT_TEXT" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')"
 
           curl -X POST $COMMENTS_URL \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
Instead of determining the PR commits URL in the code, use the PR event data provided by GitHub.

This should add support for commenting on fork PRs using `pull_request_target`.