### PR TITLE
Avoid posting comment multiple times in same PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,20 +60,37 @@ runs:
         COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
         COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       run: |
-        unsigned_commits="$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMITS_URL" | jq '.[] | select(.commit.verification.verified == false) | .commit.message')"
-        if [[ -n "$unsigned_commits" ]]; then
-          echo "Found unsigned commits:"
-          echo "$unsigned_commits"
-
-          # Escape double quotes and newlines in comment
-          COMMENT_TEXT="$(echo "$COMMENT_TEXT" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')"
-
-          curl -X POST $COMMENTS_URL \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            --data "{ \"body\": \"$COMMENT_TEXT\" }"
-
+        if [[ -z "$COMMITS_URL" ]]; then
+          echo "❌ Could not find commits to check. Make sure the action is ran on `pull_request` or `pull_request_target`"
           exit 1
         fi
 
-        echo "No unsigned commits found 🎉"
+        unsigned_commits="$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$COMMITS_URL" | jq '.[] | select(.commit.verification.verified == false) | .commit.message')"
+        if [[ -z "$unsigned_commits" ]]; then
+          echo "🎉 No unsigned commits found"
+          exit 0
+        fi
+
+        echo "🚨 Found unsigned commits:"
+        echo "$unsigned_commits"
+
+        if [[ -n "$COMMENTS_URL" ]]; then
+          echo "⏱️ Checking if comment with commit signing instructions was already posted in PR"
+
+          if curl -sf -H "Authorization: token $GITHUB_TOKEN" "$COMMENTS_URL" | jq -e --arg comment_text "$(echo "$COMMENT_TEXT" | tr -cd '[:alnum:]')" 'any(.[]; .body | gsub("[^[:alnum:]]"; "") == $comment_text)'; then
+            echo "✅ Comment already exists in PR, not posting it again"
+          else
+            echo "📤 Posting PR comment with commit signing instructions"
+
+            # Escape double quotes and newlines in comment
+            COMMENT_TEXT="$(echo "$COMMENT_TEXT" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')"
+
+            curl -X POST "$COMMENTS_URL" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              --data "{ \"body\": \"$COMMENT_TEXT\" }"
+          fi
+        fi
+
+        echo "❌ Returning with exit code 1 because of unsigned commits"
+        exit 1


### PR DESCRIPTION
The fact that the PR comment gets posted on every push if there's 1 (older) commit in the PR that's unsigned can result in noisy PRs.

So instead of posting the PR comment over and over, we'll now check the PR comments and only post the comment if it hasn't been posted earlier. This won't impact the exit code that gets returned.

Resolves #8 

Logs of test runs can be found here: [unsigned commit that results in comment](https://github.com/florisvdg/check-signed-commits-action/actions/runs/7530670921/job/20497593577) and [second unsigned commit that skips the comment](https://github.com/florisvdg/check-signed-commits-action/actions/runs/7530682003/job/20497626424).